### PR TITLE
Update dependency-review.yml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -35,6 +35,6 @@ jobs:
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
-        #   fail-on-severity: moderate
+          fail-on-severity: moderate
         #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
         #   retry-on-snapshot-warnings: true


### PR DESCRIPTION
This pull request includes a small but significant change to the `.github/workflows/dependency-review.yml` file. The change enables the `fail-on-severity` option, which was previously commented out, and sets it to `moderate`.

* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L38-R38): Enabled the `fail-on-severity` option and set it to `moderate` to ensure that the dependency review fails for any vulnerabilities of moderate severity or higher.